### PR TITLE
Support features with partially numeric names

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -139,7 +139,7 @@ module.exports = function (fileName, buildConfig = {}) {
     function buildModernizr(cb) {
 
         // get path from feature
-        let featurePaths = detectedFeatures.map(feature => feature.path.replace(/\.?\/?feature-detects\/([a-z-\/]+)\.js/, "$1"));
+        let featurePaths = detectedFeatures.map(feature => feature.path.replace(/\.?\/?feature-detects\/([a-z-0-9\/]+)\.js/, "$1"));
 
         // Output start message
         gutil.log('Detected features:');


### PR DESCRIPTION
Some of Modernizr's available features have digits in their names, but gulp-modernizr-build previously incorrectly assumed that all feature names contain only the characters a-z, /, and -. This commit simply adds 0-9 to the regex.

For example, my project uses the 'es5' feature, and I was very confused when gulp-modernizr-build crashed out from not finding it. ;)