### PR TITLE
Fix regex for detecting feature tests in CSS

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -117,7 +117,7 @@ module.exports = function (fileName, buildConfig = {}) {
 
                     featureUsed = classes.some(cssclass => {
                         let cssPropRegex;
-                        cssPropRegex = (buildConfig.cssPrefix) ? new RegExp(`html\\.(${buildConfig.cssPrefix})(no-)${cssclass}`, 'im') : new RegExp(`html\\.(no-)?${cssclass}`, 'im');
+                        cssPropRegex = (buildConfig.cssPrefix) ? new RegExp(`html\\.(${buildConfig.cssPrefix})(no-)?${cssclass}`, 'im') : new RegExp(`html\\.(no-)?${cssclass}`, 'im');
                         return cssPropRegex.test(fileContents);
                     });
 


### PR DESCRIPTION
There was a missing ? which meant that, when a prefix is set for Modernizr's classes, only the .prefix-no-feature form would be detected. This fixes that.